### PR TITLE
Fix bug with logout crash

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import React, { useState, MouseEvent } from "react";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import styled from "@emotion/styled";
 
 import { supabase } from "../helpers/supabaseClient";
@@ -22,8 +21,6 @@ interface NavbarProps {
 }
 
 const Navbar = ({ isLoggedIn }: NavbarProps) => {
-	const router = useRouter();
-
 	const [anchorEl, setAnchorEl] = useState<HTMLAnchorElement | null>(null);
 
 	const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -42,7 +39,7 @@ const Navbar = ({ isLoggedIn }: NavbarProps) => {
 		handleClose();
 
 		// Redirect to home
-		router.push("/");
+		window.location.href = "/";
 	};
 
 	return (


### PR DESCRIPTION
Switched to native `window.location.href` redirect (vs. using the Next js Router option). This forces a hard page refresh (which is desired after logging out to clear all state).